### PR TITLE
Http accepts path option

### DIFF
--- a/lib/infrataster/contexts/http_context.rb
+++ b/lib/infrataster/contexts/http_context.rb
@@ -5,7 +5,7 @@ module Infrataster
     class HttpContext < BaseContext
       def response
         server.gateway_on_from_server(resource.uri.port) do |address, port|
-          url = "#{resource.uri.scheme}://#{address}:#{port}#{resource.options[:path]}"
+          url = "#{resource.uri.scheme}://#{address}:#{port}"
 
           conn = Faraday.new(:url => url) do |faraday|
             faraday.request  :url_encoded

--- a/lib/infrataster/resources/http_resource.rb
+++ b/lib/infrataster/resources/http_resource.rb
@@ -9,7 +9,7 @@ module Infrataster
       attr_reader :uri, :options
 
       def initialize(url_str, options = {})
-        @options = {params: {}, method: :get, path: '/', headers: {}}.merge(options)
+        @options = {params: {}, method: :get, headers: {}}.merge(options)
         @uri = URI.parse(url_str)
         unless %w!http https!.include?(@uri.scheme)
           raise Error, "The provided url, '#{@uri}', is not http or https."

--- a/spec/integration/http_spec.rb
+++ b/spec/integration/http_spec.rb
@@ -24,7 +24,7 @@ describe server(:app) do
     end
   end
 
-  describe http('http://app.example.com', path: '/path/to/resource', params: {'foo' => 'bar'}, headers: {'USER' => 'VALUE'}) do
+  describe http('http://app.example.com/path/to/resource', params: {'foo' => 'bar'}, headers: {'USER' => 'VALUE'}) do
     it "sends GET request with params" do
       expect(body_as_json['method']).to eq('GET')
       expect(body_as_json['path']).to eq('/path/to/resource')


### PR DESCRIPTION
Hello,

I added another option `path` to `Http` resource so that we can write examples like:

``` ruby
describe server(:proxy) do
  describe http('http://example.com', path: '/path/to/health/check') do
    # ...
  end

  describe http('http://example.com', path: '/path/to/app') do
    # ...
  end

  describe http('http://example.com', path: '/path/to/static/file') do
    # ...
  end
end
```

We have another option to write pathinfo like this:

``` ruby
describe server(:proxy) do
  describe http('http://example.com/path/to/health/check') do
    # ...
  end
  # ...
end
```

Although I prefer the latter way, it makes it more complex: how should we do when path is specified by _both_ URI string and path option argument? So, now I have just added it only as option argument. But, if you prefer the URI string way and accept the little complexity, I'm ready to rewrite this patch. Please tell me if so.

Could you consider:
- whether to merge or not this patch?
- whether to add two way to specify path: URI string and option argument?

Thanks.

---

Just in an aside, my motivation to add path option is that:

I'm an operation engineer and our company has no server-side developer. We mainly use CMS to build web sites. So, if we need to set up a little complex routing, I have to work with web server's configuration file and, as the site grows, it gets harder not to break existing routing rules.
To do that, I need tests and refactoring.

Though adding path option may not fit your use-case because of difference of our background, Infrataster is very helpful for me and I want the option.

Anyway, thanks for the useful tool!
