### PR TITLE
fix _ssh_start_args method. invalid keyname :host changes valid keyname ...

### DIFF
--- a/lib/infrataster/server.rb
+++ b/lib/infrataster/server.rb
@@ -124,7 +124,7 @@ module Infrataster
 
       if @options[:ssh]
         config = @options[:ssh]
-        config[:host] ||= @address
+        config[:host_name] ||= @address
       elsif @options[:vagrant]
         vagrant_name = if @options[:vagrant] != true
                          @options[:vagrant]
@@ -136,7 +136,7 @@ module Infrataster
         raise Error, "Can't get configuration to connect to the server via SSH. Please set ssh option or vagrant option."
       end
 
-      [config[:host], config[:user], config]
+      [config[:host_name], config[:user], config]
     end
 
     def ssh_config_for_vagrant(name)


### PR DESCRIPTION
fix _ssh_start_args method. 
because key name ":host" is not valid for Net::SSH.
fix key name ":host" to "host_name"

in .. /vendor/bundle/ruby/2.0.0/gems/net-ssh-2.9.0/lib/net/ssh.rb

> VALID_OPTIONS = [:auth_methods, :bind_address, :compression, :compression_level, :config, :encryption, :forward_agent, :hmac, :host_key, :keepalive, :keepalive_interval, :kex, :keys, :key_data, :languages, :logger, :paranoid, :password, :port, :proxy, :rekey_blocks_limit, :rekey_limit, :rekey_packet_limit, :timeout, :verbose, :global_known_hosts_file, :user_known_hosts_file, :host_key_alias, :host_name, :user, :properties, :passphrase, :keys_only, :max_pkt_size, :max_win_size, :send_env, :use_agent] 
