### PR TITLE
Use `RSpec.current_example` in place of `example`

### DIFF
--- a/lib/infrataster/rspec.rb
+++ b/lib/infrataster/rspec.rb
@@ -10,7 +10,7 @@ RSpec.configure do |config|
     @infrataster_context = Infrataster::Contexts.from_example(self.class)
   end
   config.before(:each) do
-    @infrataster_context = Infrataster::Contexts.from_example(example)
+    @infrataster_context = Infrataster::Contexts.from_example(RSpec.current_example)
     @infrataster_context.before_each(example) if @infrataster_context.respond_to?(:before_each)
   end
   config.after(:each) do


### PR DESCRIPTION
In order to remove deprecation warning #34

(I haven't run the tests for this yet, but making this change in my bundled gem removed the deprecation warning.)
