### PR TITLE
remove mysql_query (should be in plugin)

### DIFF
--- a/lib/infrataster/helpers/resource_helper.rb
+++ b/lib/infrataster/helpers/resource_helper.rb
@@ -16,10 +16,6 @@ module Infrataster
         Resources::HttpResource.new(*args)
       end
 
-      def mysql_query(*args)
-        Resources::MysqlQueryResource.new(*args)
-      end
-
       def capybara(*args)
         Resources::CapybaraResource.new(*args)
       end


### PR DESCRIPTION
I think this was missed when the mysql_query functionality was split into the plugin. This should be placed in the mysql plugin instead of in the core code
