### PR TITLE
Added :ssl option for https connection in http resource

### DIFF
--- a/lib/infrataster/contexts/http_context.rb
+++ b/lib/infrataster/contexts/http_context.rb
@@ -6,8 +6,13 @@ module Infrataster
       def response
         server.forward_port(resource.uri.port) do |address, port|
           url = "#{resource.uri.scheme}://#{address}:#{port}"
-
-          conn = Faraday.new(:url => url) do |faraday|
+          options = {:url => url}
+          
+          if resource.uri.scheme == 'https'
+            options[:ssl] = resource.ssl_option
+          end
+          
+          conn = Faraday.new(options) do |faraday|
             faraday.request  :url_encoded
             faraday.response :logger, Logger
             faraday.adapter  Faraday.default_adapter

--- a/lib/infrataster/resources/http_resource.rb
+++ b/lib/infrataster/resources/http_resource.rb
@@ -40,6 +40,10 @@ module Infrataster
       def headers
         @options[:headers]
       end
+	  
+      def ssl_option
+        @options[:ssl]
+      end
     end
   end
 end


### PR DESCRIPTION
ssl option is added for https connection in `http` resource.
User can use this option like following:

```ruby
describe server(:app) do
  describe http('https://172.26.126.80', :ssl => { :client_cert => (OpenSSL::X509::Certificate.new(File.read('/root/https/client.crt'))), :client_key => (OpenSSL::PKey::RSA.new(File.read('/root/https/client.key')))}) do
    it "responds OK 200" do
      expect(response.status).to eq(200)
      expect(response.body).to include('Test Page')
    end
  end
end
```
