### PR TITLE
Fix spec:integration:prepare fails on chef apt-mirror

### DIFF
--- a/spec/integration/vm/cookbooks/apt-mirror/metadata.rb
+++ b/spec/integration/vm/cookbooks/apt-mirror/metadata.rb
@@ -1,0 +1,2 @@
+name 'apt-mirror'
+depends 'apt'


### PR DESCRIPTION
I had tried to run `bundle exec rake spec:integration:prepare` and got a following error.

```
:
==> proxy: [2015-01-11T06:16:54+00:00] WARN: MissingCookbookDependency:
==> proxy: Recipe `apt` is not in the run_list, and cookbook 'apt'
==> proxy: is not a dependency of any cookbook in the run_list.  To load this recipe,
==> proxy: first add a dependency on cookbook 'apt' in the cookbook you're
==> proxy: including it from in that cookbook's metadata.
==> proxy:
==> proxy: ================================================================================
==> proxy: Recipe Compile Error in /tmp/vagrant-chef-6/chef-solo-1/cookbooks/apt-mirror/recipes/default.rb
==> proxy: ================================================================================
==> proxy:
==> proxy: NoMethodError
==> proxy: -------------
==> proxy: No resource or method named `apt_installed?' for `Chef::Recipe "default"'
:
```

According to the error message, I have added metadata and dependency.
Now, it looks `bundle exec rake spec:integration:prepare` done correctly.