### PR TITLE
Add rackup host option to listen on 0.0.0.0 to pass integration test

### DIFF
--- a/spec/integration/vm/cookbooks/app/files/default/rackup.conf
+++ b/spec/integration/vm/cookbooks/app/files/default/rackup.conf
@@ -1,3 +1,3 @@
 [program:rackup]
 directory=/vagrant/app
-command=rackup -p 80 config.ru
+command=rackup -o 0.0.0.0 -p 80 config.ru


### PR DESCRIPTION
I have found an issue that fails integration test.
I have fixed it, please check it.

Then I have passed the integration test.

```
vagrant@precise64:~$ ss -ltn | grep :80
LISTEN     0      128               127.0.0.1:80                       *:*
vagrant@precise64:~$
```
:arrow_down: 
```
vagrant@precise64:~$ ss -ltn | grep :80
LISTEN     0      128                       *:80                       *:*
vagrant@precise64:~$
```
- Raason: rackup has been changed to be run on 127.0.0.1 by default.
  See: rack: Default host to localhost when in development mode.
  https://github.com/rack/rack/commit/28b014484a8ac0bbb388e7eaeeef159598ec64fc
