### PR TITLE
Change how to get current example that return nil in ver 2.14.x

### DIFF
--- a/lib/infrataster/rspec.rb
+++ b/lib/infrataster/rspec.rb
@@ -6,23 +6,23 @@ include Infrataster::Helpers::ResourceHelper
 RSpec.configure do |config|
   config.include Infrataster::Helpers::RSpecHelper
 
+  fetch_current_example = RSpec.respond_to?(:current_example) ?
+                            proc { RSpec.current_example }
+                          : proc { |context| context.example }
+
   config.before(:all) do
     @infrataster_context = Infrataster::Contexts.from_example(self.class)
   end
 
   config.before(:each) do
-    if defined?(RSpec.current_example)
-      example = RSpec.current_example
-    end
-    @infrataster_context = Infrataster::Contexts.from_example(example)
-    @infrataster_context.before_each(example) if @infrataster_context.respond_to?(:before_each)
+    current_example = fetch_current_example.call(self)
+    @infrataster_context = Infrataster::Contexts.from_example(current_example)
+    @infrataster_context.before_each(current_example) if @infrataster_context.respond_to?(:before_each)
   end
 
   config.after(:each) do
-    if defined?(RSpec.current_example)
-      example = RSpec.current_example
-    end
-    @infrataster_context.after_each(example) if @infrataster_context.respond_to?(:after_each)
+    current_example = fetch_current_example.call(self)
+    @infrataster_context.after_each(current_example) if @infrataster_context.respond_to?(:after_each)
   end
 
   config.after(:all) do
@@ -31,4 +31,3 @@ RSpec.configure do |config|
     end
   end
 end
-


### PR DESCRIPTION
## Motivation

When run `infrataster` spec using `RSpec 2.14.x`, occurs error below:

```ruby
# Gemfile
source 'https://rubygems.org'

gem 'infrataster'
gem 'rspec', '~>2.14.0'

# spec/example_spec.rb
describe server(:app) do
  it { current_server.ssh_exec("ls") }
end
```

```
$ bundle exec rspec
F

Failures:

  1) server 'app'
     Failure/Error: Unable to find matching line from backtrace
     NoMethodError:
       undefined method `metadata' for nil:NilClass
     # /path/to/infratest/vendor/bundle/ruby/2.1.0/gems/rspec-expectations-2.14.5/lib/rspec/matchers/method_missing.rb:9:in `method_missing'
     # /path/to/infratest/vendor/bundle/ruby/2.1.0/gems/infrataster-0.2.3/lib/infrataster/contexts.rb:11:in `from_example'
     # /path/to/infratest/vendor/bundle/ruby/2.1.0/gems/infrataster-0.2.3/lib/infrataster/rspec.rb:17:in `block (2 levels) in <top (required)>'
```

## Solution

I used these as reference:

- [Rspec 2 has no current_example, and rspec 3 has no example · Issue #1340 · rspec/rspec-core](https://github.com/rspec/rspec-core/issues/1340)
- https://github.com/rspec/rspec-core/blob/v2.99.0.beta2/lib/rspec/core.rb#L130-L153

## Cause

In [lib/infrataster/rspec.rb](https://github.com/ryotarai/infrataster/blob/v0.2.3/lib/infrataster/rspec.rb#L14-L16):

```ruby
if defined?(RSpec.current_example)
  example = RSpec.current_example
end
```

In this case with `RSpec 2.14.x`, `example` is redefined `local-variable`.

```ruby
p defined?(example)
if defined?(RSpec.current_example)
  example = RSpec.current_example
end
p defined?(example)
```

RSpec 3.x:

```
nil
"local-variable"
```

RSpec 2.14.8:

```
"method"
"local-vairable"
```

See also: same situtation https://gist.github.com/gongo/ab19c995f58b55a930ba