### PR TITLE
Support post method with request body

### DIFF
--- a/lib/infrataster/contexts/http_context.rb
+++ b/lib/infrataster/contexts/http_context.rb
@@ -27,6 +27,9 @@ module Infrataster
             resource.headers.each_pair do |k, v|
               req.headers[k] = v
             end
+
+            req.body = resource.body if resource.body
+
             req.url resource.uri.path
           end
         end

--- a/lib/infrataster/resources/http_resource.rb
+++ b/lib/infrataster/resources/http_resource.rb
@@ -41,6 +41,10 @@ module Infrataster
         @options[:headers]
       end
 	  
+      def body
+        @options[:body]
+      end
+
       def ssl_option
         @options[:ssl]
       end

--- a/spec/integration/http_spec.rb
+++ b/spec/integration/http_spec.rb
@@ -65,6 +65,24 @@ describe server(:app) do
     end
   end
 
+  describe http('http://app.example.com', method: :post, body: {'foo' => 'bar'}, headers: {'USER' => 'VALUE'}) do
+    it "sends POST request with body entity" do
+      expect(body_as_json['method']).to eq('POST')
+      expect(body_as_json['body']).to eq("foo=bar")
+      expect(body_as_json['headers']['USER']).not_to be_empty
+      expect(body_as_json['headers']['USER']).to eq('VALUE')
+    end
+  end
+
+  describe http('http://app.example.com', method: :post, body: {'foo' => 'bar'}.to_json, headers: {'USER' => 'VALUE'}) do
+    it "sends POST request with body entity as JSON format" do
+      expect(body_as_json['method']).to eq('POST')
+      expect(body_as_json['body']).to eq({"foo" => "bar"}.to_json)
+      expect(body_as_json['headers']['USER']).not_to be_empty
+      expect(body_as_json['headers']['USER']).to eq('VALUE')
+    end
+  end
+
   describe http('/path/to/resource') do
     it "sends GET request with scheme and host" do
       expect(body_as_json['headers']['HOST']).to eq('example.com')

--- a/spec/integration/vm/app/app.rb
+++ b/spec/integration/vm/app/app.rb
@@ -19,6 +19,7 @@ def result
     'method' => request.request_method,
     'path' => request.path_info,
     'params' => params,
+    'body' => request.body.read,
     'headers' => RequestWrapper.new(request).headers,
   }
 end


### PR DESCRIPTION
Hi, I'd like to taste infra by post method with request body, for example:

```
  describe http('/users',
                method: :post,
                headers: { "Content-Type" => 'application/json' },
                body: {"nickname" => "awesome", "device_id" => "1"}.to_json
               ) do
 
```

Thanks.