### PR TITLE
Fix for warning 

### DIFF
--- a/lib/infrataster/server.rb
+++ b/lib/infrataster/server.rb
@@ -47,6 +47,7 @@ module Infrataster
     def initialize(name, address, options = {})
       @name, @options = name, options
       @address = determine_address(address)
+      @gateway = nil
     end
 
     def from


### PR DESCRIPTION
Hi

I always got some warnings.
This is one of them: 
```
/.../infrataster-0.2.5/lib/infrataster/server.rb:72: warning: instance variable @gateway not initialized
```

The `@gateway` is used to check a statement of the connection, but it is not defined on initializer.