### PR TITLE
Fix wrong ip address

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Vagrant.configure("2") do |config|
 
   config.vm.define :proxy do |c|
     c.vm.network "private_network", ip: "192.168.33.10"
-    c.vm.network "private_network", ip: "171.16.33.10", virtualbox__intnet: "infrataster-example"
+    c.vm.network "private_network", ip: "172.16.33.10", virtualbox__intnet: "infrataster-example"
   end
 
   config.vm.define :app do |c|
-    c.vm.network "private_network", ip: "171.16.33.11", virtualbox__intnet: "infrataster-example"
+    c.vm.network "private_network", ip: "172.16.33.11", virtualbox__intnet: "infrataster-example"
   end
 end
 ```


### PR DESCRIPTION
Hi,

I found wrong ip address is put in readme vagrantfile example. It should be 172 not 171. 
With current vagrantfile example, bundle exec rspec cause Infrataster::Server::Error exception.
