### PR TITLE
Fix for berksfile warning

### DIFF
--- a/example/Berksfile
+++ b/example/Berksfile
@@ -1,2 +1,2 @@
-site :opscode
+source "https://supermarket.chef.io"
 cookbook 'apt'


### PR DESCRIPTION
Execute following commands in example directory show warning message below.
I fixed Berksfile according to warning message.
 
```bash
$bundle exec berks vendor vendor/cookbooks
DEPRECATED: Your Berksfile contains a site location pointing to the Opscode Community Site (site :opscode). Site locations have been replaced by the source location. Change this to: 'source "https://supermarket.chef.io"' to remove this warning. For more information visit https://github.com/berkshelf/berkshelf/wiki/deprecated-locations
```