### PR TITLE
Add necessary settings(name, depends) to metadata

### DIFF
--- a/example/cookbooks/app/metadata.rb
+++ b/example/cookbooks/app/metadata.rb
@@ -1,2 +1,2 @@
-name 'proxy'
+name 'app'
 depends 'apt'

--- a/example/cookbooks/db/metadata.rb
+++ b/example/cookbooks/db/metadata.rb
@@ -1,2 +1,2 @@
-name 'proxy'
+name 'db'
 depends 'apt'


### PR DESCRIPTION
Hi,

In my environment, I need this modification to make chef works.
please ignore if it's not necessary modification.

```
$vagrant --version
Vagrant 1.7.2

vagrant@precise64:~$ chef-client --version
Chef: 12.1.1
```

Here's error message I encountered without name setting in metadata file.

```
==> db: [2015-03-20T10:46:26+00:00] ERROR: Running exception handlers
==> db: [2015-03-20T10:46:26+00:00] ERROR: Exception handlers complete
==> db: [2015-03-20T10:46:26+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
==> db: [2015-03-20T10:46:26+00:00] ERROR: Cookbook loaded at path(s) [/tmp/vagrant-chef/cebd8e91b2a19e3b53a81d08826f480f/cookbooks/proxy] has invalid metadata: The `name' attribute is required in cookbook metadata
==> db: [2015-03-20T10:46:26+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```

Here's part of error message I encountered without depends 'apt' setting in metadata file.

```
==> app: [2015-03-20T13:05:41+00:00] WARN: MissingCookbookDependency:
==> app: Recipe `apt` is not in the run_list, and cookbook 'apt'
==> app: is not a dependency of any cookbook in the run_list.  To load this recipe,
==> app: first add a dependency on cookbook 'apt' in the cookbook you're
==> app: including it from in that cookbook's metadata.
==> app: 
==> app: ================================================================================
==> app: Recipe Compile Error in /tmp/vagrant-chef/cebd8e91b2a19e3b53a81d08826f480f/cookbooks/app/recipes/default.rb
==> app: ================================================================================
==> app: 
==> app: NoMethodError
==> app: -------------
==> app: No resource or method named `apt_installed?' for `Chef::Recipe "default"'
==> app: 
==> app: Cookbook Trace:
==> app: ---------------
==> app:   /tmp/vagrant-chef/fe06520fc6c351977fdc668ea1dd0e59/cookbooks/apt/recipes/default.rb:26:in `from_file'
==> app:   /tmp/vagrant-chef/cebd8e91b2a19e3b53a81d08826f480f/cookbooks/app/recipes/default.rb:1:in `from_file'
==> app: 
==> app: Relevant File Content:
==> app: ----------------------
==> app: /tmp/vagrant-chef/fe06520fc6c351977fdc668ea1dd0e59/cookbooks/apt/recipes/default.rb:
```