### PR TITLE
Fix deprecation of example_group in metadata

### DIFF
--- a/lib/infrataster/contexts.rb
+++ b/lib/infrataster/contexts.rb
@@ -8,7 +8,11 @@ module Infrataster
   module Contexts
     class << self
       def from_example(example)
-        example_group = example.metadata[:example_group]
+        example_group = if RSpec::Core::Version::STRING.start_with?('2')
+                          example.metadata[:example_group]
+                        else
+                          example.example_group
+                        end
 
         server_resource = find_described(Resources::ServerResource, example_group)
         resource = find_described(Resources::BaseResource, example_group)
@@ -28,11 +32,19 @@ module Infrataster
 
       private
       def find_described(resource_class, example_group)
-        arg = example_group[:description_args].first
+        arg = if RSpec::Core::Version::STRING.start_with?('2')
+                example_group[:description_args].first
+              else
+                example_group.metadata[:description_args].first
+              end
         if arg.is_a?(resource_class)
           arg
         else
-          parent_example_group = example_group[:example_group]
+          parent_example_group = if RSpec::Core::Version::STRING.start_with?('2')
+                                   example_group[:example_group]
+                                 else
+                                   example_group.parent_groups[1]
+                                 end
           if parent_example_group
             find_described(resource_class, parent_example_group)
           end

--- a/lib/infrataster/contexts.rb
+++ b/lib/infrataster/contexts.rb
@@ -8,14 +8,10 @@ module Infrataster
   module Contexts
     class << self
       def from_example(example)
-        example_group = if RSpec::Core::Version::STRING.start_with?('2')
-                          example.metadata[:example_group]
-                        else
-                          example.example_group
-                        end
+        eg = example_group(example)
 
-        server_resource = find_described(Resources::ServerResource, example_group)
-        resource = find_described(Resources::BaseResource, example_group)
+        server_resource = find_described(Resources::ServerResource, eg)
+        resource = find_described(Resources::BaseResource, eg)
 
         unless server_resource || resource
           # There is neither server_resource or resource
@@ -31,26 +27,40 @@ module Infrataster
       end
 
       private
+
+      def example_group(example)
+        if RSpec::Core::Version::STRING.start_with?('2')
+          example.metadata[:example_group]
+        else
+          example.example_group
+        end
+      end
+
       def find_described(resource_class, example_group)
-        arg = if RSpec::Core::Version::STRING.start_with?('2')
-                example_group[:description_args].first
-              else
-                example_group.metadata[:description_args].first
-              end
+        arg = example_group_arg(example_group)
         if arg.is_a?(resource_class)
           arg
         else
-          parent_example_group = if RSpec::Core::Version::STRING.start_with?('2')
-                                   example_group[:example_group]
-                                 else
-                                   example_group.parent_groups[1]
-                                 end
-          if parent_example_group
-            find_described(resource_class, parent_example_group)
-          end
+          parent_eg = parent_example_group(example_group)
+          find_described(resource_class, parent_eg) if parent_eg
+        end
+      end
+
+      def parent_example_group(example_group)
+        if RSpec::Core::Version::STRING.start_with?('2')
+          example_group[:example_group]
+        else
+          example_group.parent_groups[1]
+        end
+      end
+
+      def example_group_arg(example_group)
+        if RSpec::Core::Version::STRING.start_with?('2')
+          example_group[:description_args].first
+        else
+          example_group.metadata[:description_args].first
         end
       end
     end
   end
 end
-

--- a/spec/integration/spec_helper.rb
+++ b/spec/integration/spec_helper.rb
@@ -14,10 +14,11 @@ Infrataster::Server.define(
 )
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
+  if RSpec::Core::Version::STRING.start_with?('2')
+    config.treat_symbols_as_metadata_keys_with_true_values = true
+  end
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 
   config.order = 'random'
 end
-


### PR DESCRIPTION
~~Please do not merge. This pull request is work in progress.(Fri May 29 04:16:21 UTC 2015)~~
Please merge if you can accept.(Mon Jun  1 06:27:58 JST 2015)

This pull request fixes deprecation of example_group in metadata which is discussed on the issue #38.

- [X] Change code to fix deprecation of example_group in metadata
- [x] Refactor code
- [x] Check with some cases with some plugins

Please check it.