### PR TITLE
Update example README.md with helpful berks troubleshooting step

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -8,3 +8,27 @@ $ vagrant up
 $ bundle exec rspec
 ```
 
+## Troubleshooting
+
+If `vagrant up` fails due to berks failing to execute, e.g.
+
+```
+The following berks command failed to execute:
+
+    /Users/myusername/.rvm/gems/ruby-2.2.0/bin/berks --version --format json
+
+# ...
+```
+
+make sure you have ChefDK installed (`$ chef --version`), and that `which berks` points to the install prepackaged with ChefDK and not the one that comes in this Gemfile...
+
+```
+$ which berks
+/Users/myusername/.rvm/gems/ruby-2.2.0/bin/berks # no good
+
+$ PATH=/opt/chefdk/bin:$PATH
+$ which berks
+/opt/chefdk/bin/berks # good
+```
+
+Related issue here: https://github.com/berkshelf/vagrant-berkshelf/issues/264


### PR DESCRIPTION
I was unable to run the examples until I ensured that I executed the berks binary that comes packaged with ChefDK (instead of the bundled gem).

Not sure if this is the best way to identify this potential problem (or if a more direct solution is possible), but I thought this might save someone else a few minutes/hours of troubleshooting time.