### PR TITLE
add a method to return server address

### DIFF
--- a/lib/infrataster/resources/server_resource.rb
+++ b/lib/infrataster/resources/server_resource.rb
@@ -15,6 +15,10 @@ module Infrataster
         desc
       end
 
+      def address
+        server.address
+      end
+
       def server
         Server.find_by_name(@name)
       end

--- a/spec/unit/lib/infrataster/resources/server_resource_spec.rb
+++ b/spec/unit/lib/infrataster/resources/server_resource_spec.rb
@@ -3,10 +3,11 @@ require 'unit/spec_helper'
 module Infrataster
   module Resources
     describe ServerResource do
-      context "when address invoked" do
-        it "returns address" do
-          app_server = Server.new('name', '127.0.0.2')
-          expect(app_server.address).to eq('127.0.0.2')
+      context 'when invoked address' do
+        it 'returns an address' do
+          Server.define(:app, '127.0.0.1')
+          i = described_class.new(:app)
+          expect(i.address).to eq('127.0.0.1')
         end
       end
     end

--- a/spec/unit/lib/infrataster/resources/server_resource_spec.rb
+++ b/spec/unit/lib/infrataster/resources/server_resource_spec.rb
@@ -1,0 +1,14 @@
+require 'unit/spec_helper'
+
+module Infrataster
+  module Resources
+    describe ServerResource do
+      context "when address invoked" do
+        it "returns address" do
+          app_server = Server.new('name', '127.0.0.2')
+          expect(app_server.address).to eq('127.0.0.2')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
this method is useful when testing multiple servers, like
```ruby
describe server(:foo) do
  result = current_server.ssh_exec("fetch http://#{server(:bar).address}/path/to/file")
  ...
```
