### PR TITLE
Fix example referencing custom faraday middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ describe server(:app) do
   end
 
   # Custom Faraday middleware
-  describe http('http://app.example.com', faraday_middleware: [
+  describe http('http://app.example.com', faraday_middlewares: [
     YourMiddleware,
     [YourMiddleware, options]
   ]) do


### PR DESCRIPTION
There's a minor typo in the readme that threw me off for a while before I looked into the code and saw that the documentation is slightly off. Hopefully it saves somebody else some time.